### PR TITLE
improve code reliability

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,9 +11,7 @@ var windows = {}
 function createWindow(connection, opts) {
     win = new BrowserWindow(opts)
     windows[win.id] = win
-    if (opts.url) {
-        win.loadURL(opts.url)
-    }
+    win.loadURL(opts.url ? opts.url : "about:blank")
     win.setMenu(null)
     // win.webContents.openDevTools()
 


### PR DESCRIPTION
consolidate `Window` constructors
hide internal `Window` and `Application` constructors
try to avoid dying abrubtly on errors and exit
avoid hang if `url` option is not passed to the Window constructor