### PR TITLE
remove _global_windows state, add security-token, local file URI helpers

### DIFF
--- a/src/Electron.jl
+++ b/src/Electron.jl
@@ -4,6 +4,7 @@ module Electron
 using JSON, URIParser
 
 export Application, Window, URI, windows, applications
+export @LOCAL
 const OptDict = Dict{String, Any}
 
 struct JSError
@@ -307,6 +308,36 @@ function Base.close(win::Window)
     message = OptDict("cmd" => "closewindow", "winid" => win.id)
     retval = req_response(win.app, message)
     return nothing
+end
+
+"""
+    URI_file(base, filespec)
+
+Construct an absolute URI to `filespec` relative to `base`.
+"""
+URI_file(base, filespec) = URI_file(base, URI("file:///$filespec"))
+function URI_file(base, filespec::URI)
+    base = join(map(URIParser.escape, split(base, Base.Filesystem.path_separator_re)), "/")
+    return URI(filespec, path = base * filespec.path)
+end
+
+"""
+    pwd(URI)
+
+Return `pwd()` as a `URI` resource.
+"""
+Base.pwd(::Type{URI}) = URI_file(pwd(), "")
+
+"""
+    @LOCAL(filespec)
+
+Construct an absolute URI to `filespec` relative to the source file containing the macro call.
+"""
+macro LOCAL(filespec)
+    # v0.7: base = String(__source__.file)
+    #       filespec isa String && return URI_file(base, filespec) # can construct eagerly
+    #       return :(URI_file($base, $(esc(filespec))))
+    return :(URI_file(@__DIR__, $(esc(filespec))))
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,21 @@ using Electron
 using URIParser
 using Base.Test
 
+@testset "local URI" begin
+    dir = pwd(URI)
+    @test unescape(dir.path) == join(push!(split(pwd(), Base.Filesystem.path_separator_re), ""), "/")
+    @test dir.query == dir.fragment == dir.host == ""
+    @test string(dir) == "file://$(dir.path)"
+
+    __dirname = @__DIR__
+    dir = Electron.URI_file(__dirname, "")
+    @test URI(dir, path = dir.path * "test.html", query = "a", fragment = "b") ==
+        @LOCAL("test.html?a#b") ==
+        @LOCAL(begin; "test.html?a#b"; end) ==
+        Electron.URI_file(__dirname, "test.html?a#b")
+end
+
+
 @testset "Electron" begin
 
 w = Window(URI("file://test.html"))
@@ -25,7 +40,7 @@ close(w)
 @test length(applications()) == 1
 @test isempty(windows(a)) == 1
 
-w2 = Window(URI("file://test.html"))
+w2 = Window(@LOCAL("test.html"))
 
 close(a)
 @test length(applications()) == 1
@@ -35,9 +50,9 @@ sleep(1)
 @test isempty(applications())
 @test isempty(windows(a))
 
-w3 = Window(Dict("url" => string(URI("file://test.html"))))
+w3 = Window(Dict("url" => string(@LOCAL("test.html"))))
 
-w4 = Window(URI("file://test.html"), options=Dict("title" => "Window title"))
+w4 = Window(@LOCAL("test.html"), options=Dict("title" => "Window title"))
 
 w5 = Window("<body></body>", options=Dict("title" => "Window title"))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,23 +11,29 @@ a = applications()[1]
 @test isa(w, Window)
 
 @test length(applications()) == 1
-@test length(windows()) == 1
+@test length(windows(a)) == 1
 
 res = run(w, "Math.log(Math.exp(1))")
 
-@test res==1
+@test res == 1
 
 res = run(a, "Math.log(Math.exp(1))")
 
 @test res ==1
 
 close(w)
+@test length(applications()) == 1
+@test isempty(windows(a)) == 1
 
 w2 = Window(URI("file://test.html"))
 
 close(a)
+@test length(applications()) == 1
+@test length(windows(a)) == 1
 
 sleep(1)
+@test isempty(applications())
+@test isempty(windows(a))
 
 w3 = Window(Dict("url" => string(URI("file://test.html"))))
 
@@ -41,4 +47,4 @@ w6 = Window(a2, "<body></body>", options=Dict("title" => "Window title"))
 
 close(w3)
 
-end
+end # testset "Electron"


### PR DESCRIPTION
More changes. 🙂 

If you need `windows()`, it can still be defined as `foldl(append!, Window[], (windows(app) for app in Electron._global_applications))`. Do you want me to add that?

Also, this adds a set of helper function for working with local file URI objects (similar to loadFile that was recently added to Electron in https://github.com/electron/electron/issues/11560)