### PR TITLE
RFC: ElectronAPI shim object for calling BrowserWindow instance methods

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,20 @@ run(w7, "sendMessageToJulia(window.document.documentElement.innerHTML)")
 
 @test occursin("bar", take!(msgchannel(w7)))
 
+@testset "ElectronAPI" begin
+    win = Window()
+
+    @test (ElectronAPI.setBackgroundColor(win, "#000"); true)
+    @test ElectronAPI.isFocused(win) isa Bool
+
+    bounds = ElectronAPI.getBounds(win)
+    boundskeys = Set(["width", "height", "x", "y"])
+    @test boundskeys <= Set(keys(bounds))
+    @test all(isa.(get.(Ref(bounds), boundskeys, nothing), Real))
+
+    close(win)
+end
+
 close(w7)
 
 close(w3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,8 +83,8 @@ run(w7, "sendMessageToJulia(window.document.documentElement.innerHTML)")
     @test ElectronAPI.isFocused(win) isa Bool
 
     bounds = ElectronAPI.getBounds(win)
-    boundskeys = Set(["width", "height", "x", "y"])
-    @test boundskeys <= Set(keys(bounds))
+    boundskeys = ["width", "height", "x", "y"]
+    @test Set(boundskeys) <= Set(keys(bounds))
     @test all(isa.(get.(Ref(bounds), boundskeys, nothing), Real))
 
     close(win)


### PR DESCRIPTION
ATM, it's a bit tedious to call the [`BrowserWindow` API](https://electronjs.org/docs/api/browser-window).  How about adding a magic shim object `ElectronAPI` which can be used like this?

```julia
julia> using Electron

julia> win = Window();

julia> ElectronAPI.setBackgroundColor(win, "#FFF");

julia> ElectronAPI.show(win);
```

That is to say, `ElectronAPI.$method(win, $args...)` calls the JavaScript instance method `$method` with arguments `$args`.

I only implemented the instance methods for `BrowserWindow`, but I think it's easy to add API for static methods (using `ElectronAPI.$method(::Type{Window}, ...)`) and also `Application` (using `ElectronAPI.$method(::Application, ...)`).
