### PR TITLE
use `const electron = require('electron')` to make full electron available

### DIFF
--- a/src/Electron.jl
+++ b/src/Electron.jl
@@ -314,7 +314,7 @@ load(win::Window, html::AbstractString) =
     function Window([app::Application,] options::Dict)
 
 Open a new Window in the application `app`. Pass the content
-of `options` to the Electron `BrowserWindow` constructor.
+of `options` to the Electron `electron.BrowserWindow` constructor.
 
 If `app` is not specified, use the default Electron application,
 starting one if needed.
@@ -372,7 +372,7 @@ Window(a1::Application, args...; kwargs...) = throw(MethodError(Window, (a1, arg
 Window(args...; kwargs...) = Window(default_application(), args...; kwargs...)
 
 function toggle_devtools(w::Window)
-    run(w.app, "BrowserWindow.fromId($(w.id)).webContents.toggleDevTools()")
+    run(w.app, "electron.BrowserWindow.fromId($(w.id)).webContents.toggleDevTools()")
 end
 
 """
@@ -422,7 +422,7 @@ Base.getproperty(::ElectronAPIType, name::Symbol) = ElectronAPIFunction(name)
 function (api::ElectronAPIFunction)(w::Window, args...)
     name = api.name
     json_args = JSON.json(collect(args))
-    run(w.app, "BrowserWindow.fromId($(w.id)).$name(...$json_args)")
+    run(w.app, "electron.BrowserWindow.fromId($(w.id)).$name(...$json_args)")
 end
 
 end


### PR DESCRIPTION
If it wasn't intentional, the broader electron objects were being thrown away. This grabs the full electron object to allow access into the other child objects, such as `electron.screen`

This passes tests for me, but please check for correctness! I've only just started working with this package, so I may be missing a lot.

```
julia> app = Application()
...
julia> win = Window(app, URI("https://julialang.org"))
...
julia> run(win.app, "electron.screen.getAllDisplays()")
2-element Array{Any,1}:
 Dict{String,Any}("rotation" => 0,"scaleFactor" => 1,"workAreaSize" => Dict{String,Any}("height" => 480,"width" => 800),"colorSpace" => "{primaries:INVALID, transfer:INVALID, matrix:INVALID, range:INVALID}","touchSupport" => "unknown","workArea" => Dict{String,Any}("height" => 480,"x" => 1920,"width" => 800,"y" => 0),"id" => 15210126951432892,"colorDepth" => 24,"monochrome" => false,"internal" => false…)                                                               
 Dict{String,Any}("rotation" => 0,"scaleFactor" => 1,"workAreaSize" => Dict{String,Any}("height" => 1173,"width" => 1853),"colorSpace" => "{primaries_d50_referred: [[0.6833, 0.3105],  [0.2292, 0.6949],  [0.1522, 0.0578]], transfer:IEC61966_2_1, matrix:RGB, range:FULL}","touchSupport" => "unknown","workArea" => Dict{String,Any}("height" => 1173,"x" => 67,"width" => 1853,"y" => 27),"id" => 4693592448862400,"colorDepth" => 24,"monochrome" => false,"internal" => false…)
```