### PR TITLE
Make things compatible with 1.x

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,10 @@ const net = require('net')
 const os = require('os')
 const readline = require('readline')
 
+const BrowserWindow = electron.BrowserWindow;
+const app = electron.app;
+const ipcMain = electron.ipcMain;
+
 function createWindow(connection, opts) {
     if ('webPreferences' in opts) {
         opts.webPreferences['nodeIntegration'] = true


### PR DESCRIPTION
Turns out https://github.com/davidanthoff/Electron.jl/pull/62 as implemented was a breaking change and broke things like ElectronDisplay.jl. I still like the change in #62, but I don't think we should publish a breaking release for Electron.jl just for it. So this PR adds a small workaround that removes the breaking aspect.

CC @ianshmean