### PR TITLE
Changes to allow compatibility with PackageCompiler.jl

### DIFF
--- a/src/Electron.jl
+++ b/src/Electron.jl
@@ -12,8 +12,6 @@ function conditional_electron_load()
     end
 end
 
-const electronjs_path = conditional_electron_load()
-
 function prep_test_env()
     if haskey(ENV, "GITHUB_ACTIONS") && ENV["GITHUB_ACTIONS"] == "true"
         if Sys.islinux()
@@ -112,6 +110,8 @@ function generate_pipe_name(name)
 end
 
 function get_electron_binary_cmd()
+    electronjs_path = conditional_electron_load()
+    
     if electronjs_path===nothing
         return "electron"
     elseif Sys.isapple()

--- a/src/Electron.jl
+++ b/src/Electron.jl
@@ -130,9 +130,8 @@ Start a new Electron application. This will start a new process
 for that Electron app and return an instance of `Application` that
 can be used in the construction of Electron windows.
 """
-function Application()
+function Application(;mainjs=joinpath(@__DIR__, "main.js"))
     electron_path = get_electron_binary_cmd()
-    mainjs = joinpath(@__DIR__, "main.js")
 
     id = replace(string(uuid1()), "-"=>"")
     main_pipe_name = generate_pipe_name("jlel-$id")


### PR DESCRIPTION
I have been making a binary using PackageCompiler.jl and two issues came up:

* The electron artifact location was made const at precompile time. I changed this so that it is determined at runtime.
* The `main.js` file needed for Electron wouldn't be automatically distributed, and the source location is not right when determined by `@__DIR__` in a binary. So I made this an optional keyword to the `Applictaion` constructor. This might be useful in general, if people want to tweak the default behaviour in `main.js` (which I'm now thinking of doing myself).

I've tested this with my program and it successfully ran on both a Linux and a Windows machine without Julia installed. The only slightly fiddly bit was making sure the `julia_main` function required for `PackageCompiler.jl` initialised the Application with the packaged `main.js` file.