### PR TITLE
add Base.isopen(win::Window)

### DIFF
--- a/src/Electron.jl
+++ b/src/Electron.jl
@@ -390,6 +390,8 @@ function Base.close(win::Window)
     return nothing
 end
 
+Base.isopen(win::Window) = win.exists
+
 msgchannel(win::Window) = win.msg_channel
 
 """


### PR DESCRIPTION
Just a simple function that I expected to exist

i.e. so that one can do
```
isopen(win) && close(win)
```