### PR TITLE
make `--no-sandbox` optional

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,27 @@ Electron.prep_test_env()
 
     end # testset "Core"
 
+    @testset "Application options" begin
+        # Test that sandbox parameter works
+        # Note: We can't easily test the actual command line flags without deeper introspection,
+        # but we can verify the Application constructor accepts the parameter
+        
+        # Test default behavior (sandbox=false by default)
+        a1 = Application()
+        @test isa(a1, Electron.Application)
+        close(a1)
+        
+        # Test explicit sandbox=false
+        a2 = Application(sandbox=false)
+        @test isa(a2, Electron.Application)
+        close(a2)
+        
+        # Test explicit sandbox=true  
+        a3 = Application(sandbox=true)
+        @test isa(a3, Electron.Application)
+        close(a3)
+    end
+
     @testset "ElectronAPI" begin
         win = Window()
 


### PR DESCRIPTION
As a security measure this shouldn't be turned off without a way to reenable it at least.

Fixes https://github.com/davidanthoff/Electron.jl/issues/136