### PR TITLE
support overwriting of nodeIntegration and contextIsolation, prevent …

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -10,13 +10,7 @@ const app = electron.app;
 const ipcMain = electron.ipcMain;
 
 function createWindow(connection, opts) {
-    if ('webPreferences' in opts) {
-        opts.webPreferences['nodeIntegration'] = true
-        opts.webPreferences['contextIsolation'] = false
-    }
-    else {
-        opts['webPreferences'] = {nodeIntegration: true, contextIsolation: false};
-    }
+    opts.webPreferences = { nodeIntegration: true, contextIsolation: false, ...opts.webPreferences }
     var win = new electron.BrowserWindow(opts)
     win.loadURL(opts.url ? opts.url : "about:blank")
     win.setMenu(null)
@@ -29,7 +23,18 @@ function createWindow(connection, opts) {
     var win_id = win.id
 
     win.webContents.on("did-finish-load", function() {
-        win.webContents.executeJavaScript("const {ipcRenderer} = require('electron'); function sendMessageToJulia(message) { ipcRenderer.send('msg-for-julia-process', message); }; global['sendMessageToJulia'] = sendMessageToJulia;undefined")
+        win.webContents.executeJavaScript(
+            `if (typeof require !== 'undefined') {
+                const {ipcRenderer} = require('electron');
+                function sendMessageToJulia(message) {
+                    ipcRenderer.send('msg-for-julia-process', message)
+                };
+                global['sendMessageToJulia'] = sendMessageToJulia
+            } else {
+                console.info("Electron.jl: ipcRenderer is not available to send messages to the julia backend.");
+            };
+            undefined`
+        )
     })
 
     win.webContents.once("did-finish-load", function() {


### PR DESCRIPTION
Currently nodeIntegration and contextIsolation are always fix. As far as I understand that choice is made to support channel messages between Electron and Julia.
However, in some situations, e.g. for automated web app testing, it might be favorable to have the possibility to change this setting.
Moreover, Electron.jl fails to setup the message channel via ipcRenderer, when in sandbox mode. This happened to break WebAuthentication for me.

This PR introduces overwriting of nodeIntegration and contextIsolation and sets up the message channel only if available.

In that case one could introduce a default bridge via preload, which can be switched on/off via keyword.
If that's desirable, I could add it.