### PR TITLE
Add isopen(app::Application)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
   read the cookie from `process.env.JULIA_ELECTRON_SECURE_COOKIE` (and should
   `delete process.env.JULIA_ELECTRON_SECURE_COOKIE` right afterwards) instead of taking it
   from `process.argv`.
+* `isopen(app::Application)` reports whether an application is still running, the way
+  `isopen(win::Window)` already did for windows.
 * Large HTML content passed to `load(win, html)` and `Window(app, content)` is now written
   to a temporary file and loaded via a `file://` URL instead of a `data:` URL, which fixes
   hangs and blank windows for payloads above a few hundred kilobytes. The temporary files

--- a/src/Electron.jl
+++ b/src/Electron.jl
@@ -793,7 +793,21 @@ function Base.close(win::Window)
     return nothing
 end
 
+"""
+    isopen(win::Window)
+
+Return whether the window referenced by `win` still exists.
+"""
 Base.isopen(win::Window) = win.exists
+
+"""
+    isopen(app::Application)
+
+Return whether the Electron application referenced by `app` is still running. An
+application that was closed, or whose Electron process exited on its own, is no
+longer usable: any request against it throws an [`ApplicationClosedError`](@ref).
+"""
+Base.isopen(app::Application) = app.exists
 
 msgchannel(win::Window) = win.msg_channel
 

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -252,6 +252,27 @@ end
     end
 end
 
+@testitem "isopen" setup=[ElectronTestHelpers] begin
+    app = Application()
+    try
+        w = Window(app)
+
+        @test isopen(app)
+        @test isopen(w)
+
+        close(w)
+        @test wait_until(() -> !isopen(w))
+        @test isopen(app)
+
+        close(app)
+        # The application is marked dead as part of tearing the connection down,
+        # which happens asynchronously.
+        @test wait_until(() -> !isopen(app))
+    finally
+        app.exists && close(app)
+    end
+end
+
 @testitem "Requests fail with a clear error once the application is gone" setup=[ElectronTestHelpers] begin
     app = Application()
     try


### PR DESCRIPTION
`isopen` was defined for `Window` but not for `Application`, so code holding an `Application` had no public way to ask whether it was still usable — it had to reach for the private `exists` field.

That matters more since #158: a request against a dead application now throws `ApplicationClosedError`, and an application is marked dead as soon as its connection drops. Being able to check first is the natural companion to that.

```julia
app = Application()
isopen(app)   # true
close(app)
isopen(app)   # false
```

Covered by a test item asserting both the window and the application transitions, waiting on the asynchronous teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)